### PR TITLE
new: added severity() method to Report

### DIFF
--- a/src/issue.rs
+++ b/src/issue.rs
@@ -4,14 +4,16 @@ use serde::Serialize;
 
 use crate::annotation::Annotation;
 
-#[derive(Debug, PartialEq, Eq, Ord, Clone, PartialOrd, Deserialize, Serialize, JsonSchema)]
+#[derive(
+    Debug, PartialEq, Eq, Ord, Copy, Clone, PartialOrd, Deserialize, Serialize, JsonSchema,
+)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum IssueSeverity {
-    Error,
-    Warning,
-    Help,
-    Note,
     Bug,
+    Note,
+    Help,
+    Warning,
+    Error,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, JsonSchema)]

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 use crate::annotation::Annotation;
 
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, PartialEq, Eq, Ord, Clone, PartialOrd, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum IssueSeverity {
     Error,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,8 @@ impl Report {
     /// use ara_reporting::issue::Issue;
     /// use ara_reporting::issue::IssueSeverity;
     ///
+    /// let empty_report = Report::new();
+    ///
     /// let first_report = Report::new()
     ///     .with_issue(Issue::help("0001", "...", "main.ara", 10, 11))
     ///     .with_issue(Issue::warning("0002", "...", "some_file.ara", 9, 10))
@@ -88,18 +90,13 @@ impl Report {
     ///     .with_issue(Issue::bug("0003", "...", "main.ara", 10, 11))
     /// ;
     ///
-    /// assert_eq!(first_report.severity(), IssueSeverity::Warning);
-    /// assert_eq!(second_report.severity(), IssueSeverity::Error);
-    /// assert_eq!(third_report.severity(), IssueSeverity::Note);
+    /// assert_eq!(empty_report.severity(), None);
+    /// assert_eq!(first_report.severity().unwrap(), IssueSeverity::Warning);
+    /// assert_eq!(second_report.severity().unwrap(), IssueSeverity::Error);
+    /// assert_eq!(third_report.severity().unwrap(), IssueSeverity::Note);
     /// ```
-    pub fn severity(&self) -> IssueSeverity {
-        let mut highest = IssueSeverity::Bug;
-        for issue in &self.issues {
-            if highest > issue.severity {
-                highest = issue.severity.clone();
-            }
-        }
-        highest
+    pub fn severity(&self) -> Option<IssueSeverity> {
+        self.issues.iter().map(|issue| issue.severity).max()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::issue::Issue;
+use crate::issue::IssueSeverity;
 
 pub mod annotation;
 pub mod builder;
@@ -58,6 +59,47 @@ impl Report {
     pub fn with_issue(mut self, issue: Issue) -> Self {
         self.issues.push(issue);
         self
+    }
+
+    /// Returns the highest severity of all issues in this report.
+    ///
+    /// Example:
+    ///
+    /// ```rust
+    /// use ara_reporting::Report;
+    /// use ara_reporting::issue::Issue;
+    /// use ara_reporting::issue::IssueSeverity;
+    ///
+    /// let first_report = Report::new()
+    ///     .with_issue(Issue::help("0001", "...", "main.ara", 10, 11))
+    ///     .with_issue(Issue::warning("0002", "...", "some_file.ara", 9, 10))
+    ///     .with_issue(Issue::note("0003", "...", "main.ara", 10, 11))
+    /// ;
+    ///
+    /// let second_report = Report::new()
+    ///     .with_issue(Issue::warning("0001", "...", "some_file.ara", 9, 10))
+    ///     .with_issue(Issue::bug("0002", "...", "main.ara", 10, 11))
+    ///     .with_issue(Issue::error("0003", "...", "main.ara", 10, 11))
+    /// ;
+    ///
+    /// let third_report = Report::new()
+    ///     .with_issue(Issue::note("0001", "...", "main.ara", 10, 11))
+    ///     .with_issue(Issue::bug("0002", "...", "main.ara", 10, 11))
+    ///     .with_issue(Issue::bug("0003", "...", "main.ara", 10, 11))
+    /// ;
+    ///
+    /// assert_eq!(first_report.severity(), IssueSeverity::Warning);
+    /// assert_eq!(second_report.severity(), IssueSeverity::Error);
+    /// assert_eq!(third_report.severity(), IssueSeverity::Note);
+    /// ```
+    pub fn severity(&self) -> IssueSeverity {
+        let mut highest = IssueSeverity::Bug;
+        for issue in &self.issues {
+            if highest > issue.severity {
+                highest = issue.severity.clone();
+            }
+        }
+        highest
     }
 }
 


### PR DESCRIPTION
Added `severity()` method to `Report` to retrieve the highest severity from all issues in the report.

Closes: https://github.com/ara-lang/reporting/issues/4