### PR TITLE
chore: returns `Severity` from `IssueSeverity`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -252,7 +252,7 @@ impl ReportBuilder<'_> {
         }
 
         for issue in &self.report.issues {
-            let diagnostic = Into::<Diagnostic<usize>>::into(issue.severity)
+            let diagnostic = Diagnostic::new(issue.severity.into())
                 .with_code(&issue.code)
                 .with_message(&issue.message)
                 .with_labels(vec![Label::primary(
@@ -302,8 +302,11 @@ impl ReportBuilder<'_> {
         }
 
         if let Some(footer) = &self.report.footer {
-            let diagnostic: Diagnostic<usize> = Into::<Diagnostic<usize>>::into(
-                self.report.severity().unwrap_or(IssueSeverity::Error),
+            let diagnostic = Diagnostic::new(
+                self.report
+                    .severity()
+                    .unwrap_or(IssueSeverity::Error)
+                    .into(),
             )
             .with_message(&footer.message)
             .with_notes(footer.notes.clone());
@@ -312,17 +315,5 @@ impl ReportBuilder<'_> {
         }
 
         Ok(())
-    }
-}
-
-impl From<IssueSeverity> for Diagnostic<usize> {
-    fn from(severity: IssueSeverity) -> Self {
-        match severity {
-            IssueSeverity::Error => Diagnostic::error(),
-            IssueSeverity::Warning => Diagnostic::warning(),
-            IssueSeverity::Note => Diagnostic::note(),
-            IssueSeverity::Help => Diagnostic::help(),
-            IssueSeverity::Bug => Diagnostic::bug(),
-        }
     }
 }

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -219,6 +219,7 @@ impl Issue {
 ///
 /// assert_eq!(Severity::Error, IssueSeverity::Error.into());
 /// ```
+#[doc(hidden)]
 impl From<IssueSeverity> for Severity {
     fn from(severity: IssueSeverity) -> Self {
         match severity {

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -1,3 +1,4 @@
+use codespan_reporting::diagnostic::Severity;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -205,6 +206,28 @@ impl Issue {
         self.notes.push(note.into());
 
         self
+    }
+}
+
+/// Returns `Severity` from `IssueSeverity`
+///
+/// Example:
+///
+/// ```rust
+/// use codespan_reporting::diagnostic::Severity;
+/// use ara_reporting::issue::IssueSeverity;
+///
+/// assert_eq!(Severity::Error, IssueSeverity::Error.into());
+/// ```
+impl From<IssueSeverity> for Severity {
+    fn from(severity: IssueSeverity) -> Self {
+        match severity {
+            IssueSeverity::Error => Severity::Error,
+            IssueSeverity::Warning => Severity::Warning,
+            IssueSeverity::Note => Severity::Note,
+            IssueSeverity::Help => Severity::Help,
+            IssueSeverity::Bug => Severity::Bug,
+        }
     }
 }
 


### PR DESCRIPTION
I think this makes things easier to read. So, instead of:

```rust
let diagnostic = Into::<Diagnostic<usize>>::into(issue.severity)
```

We can go directly to:

```rust
let diagnostic = Diagnostic::new(issue.severity.into())
```
